### PR TITLE
fix: new output for security group id without rules dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group where the rules are added |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group where the rules are added. NOTE: This value will not be available until rules are applied, and it cannot be referenced as a remote for a rule variable for the same module block. If you need this value to use in a rule you are supplying, please use the `security_group_id_for_ref` output instead. |
+| <a name="output_security_group_id_for_ref"></a> [security\_group\_id\_for\_ref](#output\_security\_group\_id\_for\_ref) | The ID of the security group which can be used as remote reference in rules. NOTE: This value will be available as soon as the security group is created, and before rules are applied, which means it can be referenced as a remote in the rules input variable itself. If you require that all rules are applied first, please use the `security_group_id` output instead. |
 | <a name="output_security_group_rule"></a> [security\_group\_rule](#output\_security\_group\_rule) | Security group rules |
 | <a name="output_security_target"></a> [security\_target](#output\_security\_target) | Resources added to the security group |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,10 +8,15 @@ output "security_target" {
 }
 
 output "security_group_id" {
-  description = "The ID of the security group where the rules are added"
+  description = "The ID of the security group where the rules are added. NOTE: This value will not be available until rules are applied, and it cannot be referenced as a remote for a rule variable for the same module block. If you need this value to use in a rule you are supplying, please use the `security_group_id_for_ref` output instead."
   value       = local.sg_id
 
   depends_on = [ibm_is_security_group_rule.security_group_rule]
+}
+
+output "security_group_id_for_ref" {
+  description = "The ID of the security group which can be used as remote reference in rules. NOTE: This value will be available as soon as the security group is created, and before rules are applied, which means it can be referenced as a remote in the rules input variable itself. If you require that all rules are applied first, please use the `security_group_id` output instead."
+  value       = local.sg_id
 }
 
 output "security_group_rule" {


### PR DESCRIPTION
### Description

Added a new output variable `security_group_id_for_ref` that does not have a dependency on rules deployment like the current output has.

This new output will allow consumers to use this value as a "remote" reference for rules in the same module block, when a self-referencing rule is needed.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Adding a new output for Security Group ID, `security_group_id_for_ref`, which now gives two options for output of ID:
1. `security_group_id`, original output, and will not be available until all rules have been applied for this group. Continue to use this value when implicit dependencies depend on a fully deployed security group, including the rules.
2. `security_group_id_for_ref`, new output, will be available as soon as group is created and before all rules are deployed. Use this value when the rules you are supplying to the module block need a self-reference to the group being created in the same block.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
