### PR TITLE
test: add example for sg rule self reference

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -33,6 +33,7 @@ module "vpc" {
 # Update security group
 ##############################################################################
 
+# Main example of wide range of basic rules
 module "create_sgr_rule" {
   source                       = "../.."
   add_ibm_cloud_internal_rules = var.add_ibm_cloud_internal_rules
@@ -44,6 +45,7 @@ module "create_sgr_rule" {
   tags                         = var.resource_tags
 }
 
+# Example of creating new SG and rule, with the rule allowing access from another existing security group
 module "create_sgr_rule1" {
   source                       = "../.."
   add_ibm_cloud_internal_rules = var.add_ibm_cloud_internal_rules
@@ -53,6 +55,23 @@ module "create_sgr_rule1" {
     name      = "allow-all-inbound-sg"
     direction = "inbound"
     remote    = module.create_sgr_rule.security_group_id
+  }]
+  resource_group = var.resource_group != null ? data.ibm_resource_group.existing_resource_group[0].id : ibm_resource_group.resource_group[0].id
+  vpc_id         = var.vpc_id != null ? var.vpc_id : module.vpc[0].vpc_id
+  access_tags    = var.access_tags
+  tags           = var.resource_tags
+}
+
+# Example of new SG and rule, with the rule referencing the same SG that was created (self-reference)
+module "create_sgr_rule2" {
+  source                       = "../.."
+  add_ibm_cloud_internal_rules = var.add_ibm_cloud_internal_rules
+  security_group_name          = "${var.prefix}-3"
+  # sg rule referencing its own parent sg
+  security_group_rules = [{
+    name      = "allow-all-inbound-same-sg"
+    direction = "inbound"
+    remote    = module.create_sgr_rule2.security_group_id_for_ref
   }]
   resource_group = var.resource_group != null ? data.ibm_resource_group.existing_resource_group[0].id : ibm_resource_group.resource_group[0].id
   vpc_id         = var.vpc_id != null ? var.vpc_id : module.vpc[0].vpc_id


### PR DESCRIPTION
### Description

Adding new security group example to the `examples/default` to show (and test) how to create a rule within security group that has a remote pointed to the same parent security group (self-reference).

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
