### PR TITLE
fix: Fix security group rule name propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ module "create_sgr_rule" {
     name      = "allow-all-inbound"
     direction = "inbound"
     remote    = "0.0.0.0/0"
+  }, {
+    direction = "inbound"
+    remote    = "10.0.0.0/8"
   }]
   target_ids                   = ["r006-37e5b107-3006-480b-a340-bb1951357a73"]
 }
@@ -105,7 +108,7 @@ No modules.
 | <a name="input_existing_security_group_name"></a> [existing\_security\_group\_name](#input\_existing\_security\_group\_name) | Name of an existing security group. Mutually exclusive with `existing_security_group_id`. If set, rules will be added to the specified security group. | `string` | `null` | no |
 | <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | An existing resource group name to use for this example, if unset a new resource group will be created | `string` | `null` | no |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of the security group to be created | `string` | `"test-sg"` | no |
-| <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | A list of security group rules to be added to the default vpc security group | <pre>list(<br/>    object({<br/>      name       = string<br/>      direction  = string<br/>      remote     = optional(string)<br/>      local      = optional(string)<br/>      ip_version = optional(string, "ipv4")<br/>      tcp = optional(<br/>        object({<br/>          port_max = optional(number)<br/>          port_min = optional(number)<br/>        })<br/>      )<br/>      udp = optional(<br/>        object({<br/>          port_max = optional(number)<br/>          port_min = optional(number)<br/>        })<br/>      )<br/>      icmp = optional(<br/>        object({<br/>          type = optional(number)<br/>          code = optional(number)<br/>        })<br/>      )<br/>    })<br/>  )</pre> | `[]` | no |
+| <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | A list of security group rules to be added to the default vpc security group | <pre>list(<br/>    object({<br/>      name       = optional(string)<br/>      direction  = string<br/>      remote     = optional(string)<br/>      local      = optional(string)<br/>      ip_version = optional(string, "ipv4")<br/>      tcp = optional(<br/>        object({<br/>          port_max = optional(number)<br/>          port_min = optional(number)<br/>        })<br/>      )<br/>      udp = optional(<br/>        object({<br/>          port_max = optional(number)<br/>          port_min = optional(number)<br/>        })<br/>      )<br/>      icmp = optional(<br/>        object({<br/>          type = optional(number)<br/>          code = optional(number)<br/>        })<br/>      )<br/>    })<br/>  )</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | List of resource tags to apply to security group created by this module. | `list(string)` | `[]` | no |
 | <a name="input_target_ids"></a> [target\_ids](#input\_target\_ids) | (Optional) A list of target identifiers from the same VPC as the security group. It may contain one or more of the following identifiers: network interface, application load balancer, endpoint gateway, and VPN server | `list(string)` | `[]` | no |
 | <a name="input_use_existing_security_group"></a> [use\_existing\_security\_group](#input\_use\_existing\_security\_group) | If set, the modules modifies the specified existing\_security\_group\_name. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,7 @@ resource "ibm_is_security_group_rule" "security_group_rule" {
   remote     = each.value.remote
   local      = each.value.local
   ip_version = each.value.ip_version
+  name       = each.value.name
 
   ##############################################################################
   # Dynamically create ICMP Block

--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,13 @@ locals {
     }
   ]
 
-  # concatenate IBM internal rules and customer security group rules depending on add_ibm_cloud_internal_rules
-  all_rules = concat(var.security_group_rules, var.add_ibm_cloud_internal_rules ? local.ibm_cloud_internal_rules : [])
+  # add default names for customer rules when not provided, then concatenate IBM internal rules if requested
+  all_rules = concat([
+    for index, rule in var.security_group_rules :
+    merge(rule, {
+      name = rule.name != null ? rule.name : "rule-${index}"
+    })
+  ], var.add_ibm_cloud_internal_rules ? local.ibm_cloud_internal_rules : [])
 }
 
 ############################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "security_group_rules" {
   description = "A list of security group rules to be added to the default vpc security group"
   type = list(
     object({
-      name       = string
+      name       = optional(string)
       direction  = string
       remote     = optional(string)
       local      = optional(string)
@@ -142,13 +142,13 @@ variable "security_group_rules" {
   }
 
   validation {
-    error_message = "Security group rule names must match the regex pattern ^([a-z]|[a-z][-a-z0-9_]*[a-z0-9])$."
+    error_message = "Security group rule names must match the regex pattern ^([a-z]|[a-z][-a-z0-9_]*[a-z0-9])$ when specified."
     condition = (var.security_group_rules == null || length(var.security_group_rules) == 0) ? true : length(distinct(
       flatten([
         # Check through rules
         for rule in var.security_group_rules :
-        # Return false if direction is not valid
-        false if !can(regex("^([a-z]|[a-z][-a-z0-9_]*[a-z0-9])$", rule.name))
+        # Return false if name is set and is not valid
+        false if(rule.name != null && !can(regex("^([a-z]|[a-z][-a-z0-9_]*[a-z0-9])$", rule.name)))
       ])
     )) == 0
   }


### PR DESCRIPTION
### Description

- Adds support for propagating the input rule `name` into  `ibm_is_security_group_rule` resource.

issue : https://github.com/terraform-ibm-modules/terraform-ibm-security-group/issues/459

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Fixed an issue where security group rule names provided through `security_group_rules` were not applied to created IBM Cloud security group rules
- Security group rules will now use the provided name value via `var.security_group_rules` instead of provider-generated rule names

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
